### PR TITLE
Detect tasks changes instead of apps changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,10 +95,24 @@ function listChildren() {
         return;
       }
 
-      children = children.filter(function (child) {
-        return child.search('app') === 0;
+      // List the running apps
+      var apps = children
+        .filter(function (child) {
+          return child.search('app') === 0;
+        })
+        .map(function (child) {
+          return child.substr(child.indexOf(':') + 1);
+        });
+
+      // List the tasks for the running apps
+      var tasks = children.filter(function (child) {
+        if (child.search('tasks') !== 0) {
+          return false;
+        }
+        var appName = child.substr(child.indexOf(':') + 1);
+        return (apps.indexOf(appName) !== -1);
       });
-      children.forEach(watchData);
+      tasks.forEach(watchData);
     }
   );
 }

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function listChildren() {
       // List the running apps
       var apps = children
         .filter(function (child) {
-          return child.search('app') === 0;
+          return child.indexOf('app') === 0;
         })
         .map(function (child) {
           return child.substr(child.indexOf(':') + 1);
@@ -106,7 +106,7 @@ function listChildren() {
 
       // List the tasks for the running apps
       var tasks = children.filter(function (child) {
-        if (child.search('tasks') !== 0) {
+        if (child.indexOf('tasks') !== 0) {
           return false;
         }
         var appName = child.substr(child.indexOf(':') + 1);


### PR DESCRIPTION
- apps change when you update the number of instances
- tasks change when an instance is modified

If you watch only the app, you will get only the old endpoints.
You have to wait for the new instance.

Fix #5
