### PR TITLE
Use js-yaml instead yaml to parse the YAML files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "config": "^0.4.35"
   },
   "optionalDependencies": {
-    "yaml": "^0.2.3"
+    "js-yaml": "^3.0.2"
   },
   "devDependencies": {
     "jshint": "*"


### PR DESCRIPTION
https://github.com/visionmedia/js-yaml is old, not maintained and doesn't support the entire YAML specification.

https://github.com/nodeca/js-yaml is well maintained and have a pretty good support of the YAML specification.

https://github.com/lorenwest/node-config will detect that `js-yaml` is available and use it.
